### PR TITLE
Bug fixes for monthly analysis

### DIFF
--- a/payload/usr/local/bin/nettopstats
+++ b/payload/usr/local/bin/nettopstats
@@ -165,6 +165,7 @@ def present_analysis(output_dir, period):
                 if current_month != file_month and current_month != 0:
                     print('\nMonth {}'.format(current_month))
                     display_stats(old_stats)
+                    old_stats = {}
                 else:
                     old_stats = merge_dicts(old_stats, new_stats)
                 current_month = file_month
@@ -172,6 +173,7 @@ def present_analysis(output_dir, period):
     if period != 'daily':
         if current_month != 0:
             print('\nMonth {}'.format(current_month))
+            old_stats = merge_dicts(old_stats, new_stats)
             display_stats(old_stats)
 
 def main():


### PR DESCRIPTION
Before, there was a faulty assumption that the same month number would necessarily be the same month. In theory (though this would be highly unlikely), you could have run this for the entire month of August, 2020 and then not run it again until August, 2021, and `nettopstats` would consider those two months a year apart to be the same month.

Also cleans up the data by resetting the `old_stats` dictionary.