### PR TITLE
Increase interval to 15 minutes from 15 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Accumulates daily outputs of the nettop command
 
 ## What does nettopstats do?
-It basically runs the `nettop` command every 15 seconds and saves the output to one .json file per day.
+It basically runs the `nettop` command every 15 minutes and saves the output to one .json file per day.
 
 ## How does nettopstats differ from other projects?
 I'd love to be proven wrong, but at least as of the creation of nettopstats, it didn't appear that there were any projects that fit the following criteria:
@@ -16,7 +16,7 @@ I'd love to be proven wrong, but at least as of the creation of nettopstats, it 
 - [munkipkg](https://github.com/munki/munki-pkg) (to build the installer package) **If you're not going to use `/usr/bin/python3`, change the path in the `nettopstats` script to wherever your Python 3 is _before_ you build the pkg**
 
 ## How resource-intensive is this?
-I don't know. This project may be a total failure in terms of resources. I've set it to run every 15 seconds. That's quite often, but it's also just doing a very quick dump of `nettop` output, so it may not be resource-intensive at all.
+I don't know. This project may be a total failure in terms of resources. I've set it to run every 15 minutes. That's quite often, but it's also just doing a very quick dump of `nettop` output, so it may not be resource-intensive at all.
 
 ## How do you use nettopstats?
 If you build and install the pkg, it should just run by itself, and then dump out daily .json files to `~/Library/Application Support/nettopstats`.
@@ -24,9 +24,7 @@ If you build and install the pkg, it should just run by itself, and then dump ou
 If you want to analyze the results later, run `/usr/local/bin/nettopstats --analyze daily` or `/usr/local/bin/nettopstats --analyze monthly`.
 
 ## How accurate is this tool?
-Even in theory, not 100% accurate, to be honest. Keep in mind, since it's running every 15 seconds and not all the time in the background, the data may be useful (just to see what processes are using the most bandwidth), but the total bytes in and total bytes out won't precisely reflect actual usage. Some bytes in and out won't be captured fully by a check that happens only every 15 seconds.
-
-From the actual testing I've done so far, the numbers for Google Chrome are wildly inflated, for some reason (hundreds of GB, when it really should be single digits GB), so this seems to be more of a proof-of-concept, at this point.
+I don't know. When I was sampling every 2, 5, 10, or 15 seconds, it seems the numbers were significantly inflated (hundreds of GB instead of single digits of GB), so I don't know exactly how the sampling for `nettop -L 1` works. Currently trying to run only every 15 minutes or so to see if that's closer to actual usage.
 
 Also, standard Python (you can import special libraries) is annoying with time zones, so the by-day .json log is by whatever the time is in UTC, so you may start seeing data not exactly line up with today or yesterday, but if you just want to know roughly what's using the most bandwidth, it may not matter. Just something to keep in mind.
 

--- a/build-info.plist
+++ b/build-info.plist
@@ -19,6 +19,6 @@
 	<key>suppress_bundle_relocation</key>
 	<true/>
 	<key>version</key>
-	<string>1.1</string>
+	<string>1.2</string>
 </dict>
 </plist>

--- a/payload/Library/LaunchAgents/com.github.nettopstats.plist
+++ b/payload/Library/LaunchAgents/com.github.nettopstats.plist
@@ -11,7 +11,7 @@
 	<key>RunAtLoad</key>
 	<true/>
     <key>StartInterval</key>
-    <integer>15</integer>
+    <integer>900</integer>
     <key>ThrottleInterval</key>
     <integer>0</integer>
 </dict>


### PR DESCRIPTION
There isn't good documentation on how the `nettop` sampling works, but it's pretty clear that if you run `nettop -L 1` too often, it's just repeating essentially the same data:
```
hostname: ~ username$ nettop -L 1 | grep firefox
18:00:12.781240,firefox.366,,,9395727,512215,8180,0,2415,,,,,,,,,,,,
hostname: ~ username$ nettop -L 1 | grep firefox
18:00:14.382647,firefox.366,,,9395727,512467,8180,0,2541,,,,,,,,,,,,
hostname: ~ username$ nettop -L 1 | grep firefox
18:00:15.549484,firefox.366,,,9367167,508473,8180,0,2415,,,,,,,,,,,,
hostname: ~ username$ nettop -L 1 | grep firefox
18:00:17.023008,firefox.366,,,9367167,508473,8180,0,2415,,,,,,,,,,,,
hostname: ~ username$ nettop -L 1 | grep firefox
18:00:18.139384,firefox.366,,,9367167,508473,8180,0,2415,,,,,,,,,,,,
hostname: ~ username$ nettop -L 1 | grep firefox
18:00:22.336131,firefox.366,,,9362116,506633,8180,0,2415,,,,,,,,,,,,
```
I didn't use an additional 9 MB between 18:00:17.023008 and 18:00:18.139384. So adding that all up will just artificially inflate the bandwidth numbers. I don't know what rate it refreshes at with new data, so I'm trying a 15-minute interval.